### PR TITLE
Servidor de Express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "mongoose": "^8.7.1",
         "nodemon": "^3.1.7"
@@ -280,6 +281,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "SQL-Slayer",
   "license": "ISC",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "mongoose": "^8.7.1",
     "nodemon": "^3.1.7"

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,0 +1,9 @@
+require("dotenv").config();
+const express = require("express");
+
+const servidor = express();
+servidor.use(express.json());
+
+servidor.listen(process.env.PORT, () => {
+  console.log(`Servidor escuchando en el puerto ${process.env.PORT}.`);
+});


### PR DESCRIPTION
# Cambios

- Se implementa el servidor Express en `src/server/app.js`, que escuchará el puerto según la variable de entorno `PORT`.
- Se añade la dependencia `dotenv` para importar variables de entorno.