### PR TITLE
Se cambia el atributo tipo por el de cargo

### DIFF
--- a/src/Models/empleado.js
+++ b/src/Models/empleado.js
@@ -5,7 +5,7 @@ const empleadoSchema = new Schema({
   nombre: { type: String, required: true },
   apellidoPaterno: { type: String, required: true },
   apellidoMaterno: { type: String, required: true },
-  tipo: { type: String, required: true },  // Ej. intendente, entrenador
+  cargo: { type: String, required: true },  // Ej. intendente, entrenador
   sueldo: { type: Number, required: true },
   telefono: { type: String, required: true },
   telefonoEmergencia: { type: String },


### PR DESCRIPTION
Se cambia el atributo `tipo` por el de `cargo`, para agregar legibilidad y estar conforme al último esquema global.